### PR TITLE
fix: add subpath exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
 	"description": "A prism fork intended for ESM",
 	"type": "module",
 	"main": "prism.js",
+  "exports": {
+    ".": "prism.js",
+    "./*": "./*"
+  },
 	"style": "themes/prism.css",
 	"engines": {
 		"node": ">=6"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"main": "prism.js",
   "exports": {
-    ".": "prism.js",
+    ".": "./prism.js",
     "./*": "./*"
   },
 	"style": "themes/prism.css",


### PR DESCRIPTION
Hopefully fix this error from JSPM generator:
```
Error: No './components/prism-markup.js' exports subpath defined in https://ga.jspm.io/npm:prism-esm@1.29.0-fix.4/ resolving prism-esm/components/prism-markup.js imported from ./elements/rh-code-block/prism.js.
     at throwExportNotDefined (./node_modules/@jspm/generator/dist/generator-94df858f.js:1742:19)
     at Resolver.resolveExport (./node_modules/@jspm/generator/dist/generator-94df858f.js:1774:17)
     at async TraceMap.resolve (./node_modules/@jspm/generator/dist/generator-94df858f.js:3022:59)
     at async TraceMap.visit (./node_modules/@jspm/generator/dist/generator-94df858f.js:2808:26)
     at async ./node_modules/@jspm/generator/dist/generator-94df858f.js:2845:13
     at async Promise.all (index 8)
     at async TraceMap.visit (./node_modules/@jspm/generator/dist/generator-94df858f.js:2840:9)
     at async ./node_modules/@jspm/generator/dist/generator-94df858f.js:2845:13
     at async Promise.all (index 9)
     at async TraceMap.visit (./node_modules/@jspm/generator/dist/generator-94df858f.js:2840:9)
     at async Generator._install (./node_modules/@jspm/generator/dist/generator-94df858f.js:4112:13)
     at async generateImportMap (./docs/_plugins/shortcodes/renderInstallation.cjs:13:3)
     at async Object.renderInstall (./docs/_plugins/shortcodes/renderInstallation.cjs:86:3)
```